### PR TITLE
use same versions of findbugs / error prone as guava

### DIFF
--- a/guava-preconditions/build.gradle
+++ b/guava-preconditions/build.gradle
@@ -34,8 +34,8 @@ sourceSets {
 // tag::dependencies[]
 dependencies {
     // only needed for annotations
-    compile 'com.google.code.findbugs:jsr305:3.0.0'
-    compile 'com.google.errorprone:error_prone_annotations:2.0.4'
+    compile 'com.google.code.findbugs:jsr305:1.3.9'
+    compile 'com.google.errorprone:error_prone_annotations:2.0.2'
 
     testCompile 'junit:junit:4.11'
 }


### PR DESCRIPTION
Note: v18 does not appear to have "error_prone_annotations"
